### PR TITLE
fix: calculate version / release when using skip release

### DIFF
--- a/.github/workflows/default-tool-pr-review.yaml
+++ b/.github/workflows/default-tool-pr-review.yaml
@@ -3,9 +3,9 @@ name: Default Review Pull Request
 on:
   workflow_call:
     outputs:
-      REVIEW_OK:
+      review_ok:
         description: "Is the PR ok"
-        value: ${{ jobs.pr-review-summary.outputs.REVIEW_OK }}
+        value: ${{ jobs.pr-review-summary.outputs.review_ok }}
     secrets:
       SOURCE_KEY:
         required: true
@@ -85,7 +85,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     outputs:
-      REVIEW_OK: ${{ steps.comment_body.outputs.REVIEW_OK }}
+      review_ok: ${{ steps.comment_body.outputs.review_ok }}
     steps:
       - name: Set up Python
         uses: actions/setup-python@v3
@@ -144,10 +144,10 @@ jobs:
           # check if all_checks are true
           if all(all_checks):
             header = "👋 Hi there! I have checked your PR and found no issues. Thanks for your contribution!\n"
-            set_output('REVIEW_OK', 'true')
+            set_output('review_ok', 'true')
           else:
             header = "👋 Hi there! I have checked your PR and found the following:\n\n"
-            set_output('REVIEW_OK', 'false')
+            set_output('review_ok', 'false')
           
           body = header + review_str
           
@@ -224,5 +224,5 @@ jobs:
             })
 
       - name: Fail if linting failed
-        if: steps.comment_body.outputs.REVIEW_OK == 'false'
+        if: steps.comment_body.outputs.review_ok == 'false'
         run: exit 1

--- a/.github/workflows/default-tool-pr-review.yaml
+++ b/.github/workflows/default-tool-pr-review.yaml
@@ -2,6 +2,10 @@ name: Default Review Pull Request
 
 on:
   workflow_call:
+    outputs:
+      REVIEW_OK:
+        description: "Is the PR ok"
+        value: ${{ jobs.pr-review-summary.outputs.REVIEW_OK }}
     secrets:
       SOURCE_KEY:
         required: true
@@ -80,6 +84,8 @@ jobs:
     needs: [ load-config, pr-review, python-review, docker-review, gitops-review ]
     if: always()
     runs-on: ubuntu-latest
+    outputs:
+      REVIEW_OK: ${{ steps.comment_body.outputs.REVIEW_OK }}
     steps:
       - name: Set up Python
         uses: actions/setup-python@v3

--- a/.github/workflows/default-tool-pr-review.yaml
+++ b/.github/workflows/default-tool-pr-review.yaml
@@ -76,7 +76,7 @@ jobs:
       GITOPS_KEY: ${{ secrets.GITOPS_KEY }}
 
   pr-review-summary:
-    name: Python Check Pull Request
+    name: Generate Pull Request Summary
     needs: [ load-config, pr-review, python-review, docker-review, gitops-review ]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/tool-generate-semantic-version.yaml
+++ b/.github/workflows/tool-generate-semantic-version.yaml
@@ -16,7 +16,7 @@ on:
         description: "python-semantic-release pkg to use"
         type: string
         required: false
-        default: "8.1.1"
+        default: "8.5.1"
       release_override:
         description: "if set this will override semantic release and labels used"
         type: string

--- a/.github/workflows/tool-generate-semantic-version.yaml
+++ b/.github/workflows/tool-generate-semantic-version.yaml
@@ -18,7 +18,7 @@ on:
         required: false
         default: "8.1.1"
       release_override:
-        description: "if blank it will not run"
+        description: "if set this will override semantic release and labels used"
         type: string
         required: false
         default: ""
@@ -45,7 +45,7 @@ jobs:
 
   generateRelease:
     needs: pr-version-calculate
-    if: always()
+    if: ${{ needs.pr-version-calculate.outputs.is_release == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -68,9 +68,9 @@ jobs:
             with open(os.environ['GITHUB_ENV'], 'a') as fh:
                 print(f'{name}={value}', file=fh)
           
-          bump_level = "${{ needs.pr-version-calculate.outputs.calculated_bump_level }}"
-          if bump_level != '':
-            set_env('RELEASE_OVERRIDE', bump_level)  
+          release_override_found = "${{ needs.pr-version-calculate.outputs.release_override_found }}"
+          if release_override_found != '':
+            set_env('RELEASE_OVERRIDE', release_override_found)  
           
 
       - name: Set up Python ${{ inputs.python_version }}

--- a/.github/workflows/tool-load-config.yaml
+++ b/.github/workflows/tool-load-config.yaml
@@ -1,4 +1,4 @@
-name: Load toml config "${{ inputs.config_toml_file }}"
+name: Load toml config
 
 on:
   workflow_call:
@@ -56,7 +56,7 @@ on:
 
 jobs:
   config:
-    name: Load toml config
+    name: Load toml config "${{ inputs.config_toml_file }}"
     runs-on: ubuntu-latest
     outputs:
       docker_enabled: ${{ steps.config.outputs.docker_enabled }}

--- a/.github/workflows/tool-load-config.yaml
+++ b/.github/workflows/tool-load-config.yaml
@@ -1,4 +1,4 @@
-name: Load toml config
+name: Load toml config "${{ inputs.config_toml_file }}"
 
 on:
   workflow_call:

--- a/.github/workflows/tool-pr-linter.yaml
+++ b/.github/workflows/tool-pr-linter.yaml
@@ -103,9 +103,8 @@ jobs:
           
           if len(intersect_labels) == 0:
             set_env("ADD_DEFAULT_LABEL", "true")
-            set_output("contains_release_label", "true")
-          else:
-            set_output("contains_release_label", "true")
+            
+          set_output("contains_release_label", "true")
 
 
       - name: Add default labels to selection

--- a/.github/workflows/tool-pr-linter.yaml
+++ b/.github/workflows/tool-pr-linter.yaml
@@ -97,16 +97,15 @@ jobs:
                 print(f'{name}={value}', file=fh)
           
           label_names = json.loads(os.environ['LABELS'])
-          valid_labels = set(['release-auto', 'release-patch', 'release-minor', 'release-major', 'release-skip'])
+          valid_labels = {'release-auto', 'release-patch', 'release-minor', 'release-major', 'release-skip'}
           
-          if len(label_names) == 0:
+          intersect_labels = valid_labels.intersection(label_names)
+          
+          if len(intersect_labels) == 0:
             set_env("ADD_DEFAULT_LABEL", "true")
             set_output("contains_release_label", "true")
           else:
-            if len(valid_labels.intersection(label_names)) == 0:
-              set_output("contains_release_label", "false")
-            else:
-              set_output("contains_release_label", "true")
+            set_output("contains_release_label", "true")
 
 
       - name: Add default labels to selection

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -82,12 +82,10 @@ jobs:
           all_tags = os.popen('git tag').read().splitlines()
           semver_tags = [tag for tag in all_tags if re.match(r'^v\d+\.\d+\.\d+$', tag)]
           if semver_tags:
-              # get the latest semver tag
-              semver_tags.sort(key=lambda s: list(map(int, s[1:].split('.'))), reverse=True)
-              latest_semver_tag = semver_tags[0]
+              latest_semver_tag = semver_tags[-1]
           else:
               latest_semver_tag = 'v0.0.0'  # default if no semver tags found
-
+          
           set_env("LATEST_RELEASE_TAG", latest_semver_tag)
 
       - name: Check the calculated version from semantic release
@@ -106,7 +104,7 @@ jobs:
                   print(f"{name}={value}", file=fh)
       
           label_names = json.loads(os.environ["LABELS"])
-          rel_labels = [l for l in label_names if l.startswith("release-")]
+          rel_labels = {l for l in label_names if l.startswith("release-")}
           if len(rel_labels) == 0:
               rel_labels.append("release-skip")
       
@@ -126,25 +124,22 @@ jobs:
           }
       
           valid_labels = set(release_label_map.keys())
-          release_labels_found = len(valid_labels.intersection(set(rel_labels)))
-          if release_labels_found != 1:
-              if len(rel_labels) > 1:
-                  print("Multiple release labels found, please only use one release label")
-              else:
-                  print("No valid release label found, please use one of:")
-                  print(valid_labels)
+          release_labels = valid_labels.intersection(set(rel_labels))
+          num_release_labels_found = len(release_labels) 
+          if num_release_labels_found != 1:
+              print("Multiple release labels found, please only use one release label")             
               # exit, if multiple is set, then something is wrong and we really do not want to do any release
               exit(1)
       
-          release_label = rel_labels[0]
+          release_label = release_labels[0]
           forced_release = release_label_map[release_label]
       
           # temp debug..
-          print(rel_labels)
-          print(release_labels_found)
-          print(release_label)
-          print(forced_release)
-          print(os.getenv("LATEST_RELEASE_TAG"))
+          print(f"{rel_labels=}")
+          print(f"{release_labels_found=}")
+          print(f"{release_label=}")
+          print(f"{forced_release=}")
+          print("LATEST_RELEASE_TAG"+os.getenv("LATEST_RELEASE_TAG"))
       
           if release_label == "release-skip":
               # exit if skip release
@@ -175,8 +170,8 @@ jobs:
           new_version = f"v{output}"
       
           # debug print
-          print(cur_version)
-          print(new_version)
+          print(f"{cur_version=}")
+          print(f"{new_version=}")
       
           if cur_version != new_version:
               set_output("new_version", str(output))

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -29,6 +29,9 @@ on:
       is_release:
         description: "Is set to 'true' if its a release"
         value: ${{ jobs.version_calc.outputs.is_release }}
+      issue_str:
+        description: "Issue string"
+        value: ${{ jobs.version_calc.outputs.issue_str }}
     secrets:
       SOURCE_KEY:
         required: false
@@ -45,6 +48,7 @@ jobs:
       calculated_version: ${{ steps.calculate_version.outputs.new_version }}
       release_override_found: ${{ steps.calculate_version.outputs.release_override_found }}
       is_release: ${{ steps.calculate_version.outputs.is_release }}
+      issue_str: ${{ steps.calculate_version.outputs.issue_str }}
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4
@@ -127,8 +131,9 @@ jobs:
           release_labels = valid_labels.intersection(set(rel_labels))
           num_release_labels_found = len(release_labels) 
           if num_release_labels_found != 1:
-              print("Multiple release labels found, please only use one release label")             
+              print("Multiple release labels found, please only use one release label")
               # exit, if multiple is set, then something is wrong and we really do not want to do any release
+              set_output("issue_str", "Multiple release labels found, please only use one release label")
               exit(1)
       
           release_label = release_labels[0]

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -104,9 +104,12 @@ jobs:
           import json
 
           def set_output(name, value):
-              with open(os.environ["GITHUB_OUTPUT"], "w") as fh:
-                  print(f"{name}={value}", file=fh)
-      
+              with open(os.environ['GITHUB_ENV'], 'r') as fh:
+                  data = fh.read().strip()
+              with open(os.environ['GITHUB_ENV'], 'w') as fh:
+                  data += f"\n{name}={value}\n"    
+                  fh.write(data)
+          
           label_names = json.loads(os.environ["LABELS"])
           rel_labels = {l for l in label_names if l.startswith("release-")}
           if len(rel_labels) == 0:

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -130,7 +130,7 @@ jobs:
           print(release_labels_found)
           print(release_label)
           print(forced_release)
-          print(${{ env.LATEST_RELEASE_TAG }})
+          print("${{ env.LATEST_RELEASE_TAG }}")
 
           if release_labels_found != 1:
             # exit, if multible is set, then something is wrong and we really do not want to do any release
@@ -160,7 +160,7 @@ jobs:
           print(f'Captured Version Name: "{output}"')
 
           # Compare current tag with new so we know if its new
-          if "v" + str(output) != ${{ env.LATEST_RELEASE_TAG }}:
+          if "v" + str(output) != "${{ env.LATEST_RELEASE_TAG }}":
             set_output('version', str(output))
             set_output('release_override_found', forced_release)
             set_output('is_release', "true")

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -128,11 +128,11 @@ jobs:
             # exit, if multible is set, then something is wrong and we really do not want to do any release
             return
 
-          if release_label == "release-skip"
+          if release_label == "release-skip":
             # exit if skip release
             return
           
-          if forced_release != ""
+          if forced_release != "":
             command.append(forced_release)
 
 

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -141,7 +141,7 @@ jobs:
       
           # temp debug..
           print(f"{rel_labels=}")
-          print(f"{release_labels_found=}")
+          print(f"{num_release_labels_found=}")
           print(f"{release_label=}")
           print(f"{forced_release=}")
           print("LATEST_RELEASE_TAG"+os.getenv("LATEST_RELEASE_TAG"))

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -111,6 +111,7 @@ jobs:
           }
 
           release_label = "release-skip"
+          forced_release = ""
 
           def check_label(label_name):
               if label_name in release_label_map:
@@ -125,6 +126,7 @@ jobs:
               release_labels_found += check_label(label)
 
           # temp debug..
+          print(rel_labels)
           print(release_labels_found)
           print(release_label)
           print(forced_release)

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -161,9 +161,12 @@ jobs:
 
           # Compare current tag with new so we know if its new
 
-          if f"v{output}" is not "${{ env.LATEST_RELEASE_TAG }}":
-            print("${{ env.LATEST_RELEASE_TAG }}")
-            print(f"v{output}")
-            set_output('version', str(output))
+          cur_version = "${{ env.LATEST_RELEASE_TAG }}"
+          new_version = f"v{output}"
+
+          if cur_version != new_version:
+            print(cur_version)
+            print(new_version)
+            set_output('version', new_version)
             set_output('release_override_found', forced_release)
             set_output('is_release', "true")

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -160,11 +160,10 @@ jobs:
           print(f'Captured Version Name: "{output}"')
 
           # Compare current tag with new so we know if its new
-          print("${{ env.LATEST_RELEASE_TAG }}")
-          print("v" + str(output)+"X")
 
-
-          if "v" + str(output) != "${{ env.LATEST_RELEASE_TAG }}":
+          if f"v{output}" is not "${{ env.LATEST_RELEASE_TAG }}":
+            print("${{ env.LATEST_RELEASE_TAG }}")
+            print(f"v{output}")
             set_output('version', str(output))
             set_output('release_override_found', forced_release)
             set_output('is_release', "true")

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install toml==0.10.2 python-semantic-release==8.1.1
+          pip install toml==0.10.2 python-semantic-release==8.5.1
 
       - name: Get latest release tag
         shell: python
@@ -104,7 +104,7 @@ jobs:
           import json
 
           def set_output(name, value):
-              with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+              with open(os.environ["GITHUB_OUTPUT"], "w") as fh:
                   print(f"{name}={value}", file=fh)
       
           label_names = json.loads(os.environ["LABELS"])
@@ -180,7 +180,7 @@ jobs:
           print(f"{new_version=}")
       
           if cur_version != new_version:
-              print("New version found")
-              set_output("new_version", str(output))
-              set_output("release_override_found", forced_release)
-              set_output("is_release", "true")
+            print("New version found")
+            set_output("new_version", output)
+            set_output("release_override_found", forced_release)
+            set_output("is_release", "true")

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -130,7 +130,7 @@ jobs:
           print(release_labels_found)
           print(release_label)
           print(forced_release)
-          print(env.LATEST_RELEASE_TAG)
+          print(${{ env.LATEST_RELEASE_TAG }})
 
           if release_labels_found != 1:
             # exit, if multible is set, then something is wrong and we really do not want to do any release
@@ -160,7 +160,7 @@ jobs:
           print(f'Captured Version Name: "{output}"')
 
           # Compare current tag with new so we know if its new
-          if "v" + str(output) != env.LATEST_RELEASE_TAG:
+          if "v" + str(output) != ${{ env.LATEST_RELEASE_TAG }}:
             set_output('version', str(output))
             set_output('release_override_found', forced_release)
             set_output('is_release', "true")

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -110,7 +110,7 @@ jobs:
           label_names = json.loads(os.environ["LABELS"])
           rel_labels = {l for l in label_names if l.startswith("release-")}
           if len(rel_labels) == 0:
-              rel_labels.append("release-skip")
+              rel_labels.add("release-skip")
       
           # Command to execute
           command = ["semantic-release", "--config", os.getenv("TOML_FILE"), "--noop", "version"]
@@ -128,7 +128,7 @@ jobs:
           }
       
           valid_labels = set(release_label_map.keys())
-          release_labels = valid_labels.intersection(set(rel_labels))
+          release_labels = valid_labels.intersection(rel_labels)
           num_release_labels_found = len(release_labels) 
           if num_release_labels_found != 1:
               print("Multiple release labels found, please only use one release label")
@@ -136,7 +136,7 @@ jobs:
               set_output("issue_str", "Multiple release labels found, please only use one release label")
               exit(1)
       
-          release_label = release_labels[0]
+          release_label = list(rel_labels)[0]
           forced_release = release_label_map[release_label]
       
           # temp debug..

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -115,7 +115,7 @@ jobs:
           def check_label(label_name):
               if label_name in release_label_map:
                   release_label = label_name
-                  forced_release release_label_map[label_name]
+                  forced_release = release_label_map[label_name]
                   return 1
               return 0
 

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -138,13 +138,14 @@ jobs:
       
           release_label = list(rel_labels)[0]
           forced_release = release_label_map[release_label]
+          latest_release_tag = os.getenv("LATEST_RELEASE_TAG")
       
           # temp debug..
           print(f"{rel_labels=}")
           print(f"{num_release_labels_found=}")
           print(f"{release_label=}")
           print(f"{forced_release=}")
-          print("LATEST_RELEASE_TAG"+os.getenv("LATEST_RELEASE_TAG"))
+          print(f"{latest_release_tag=}")
       
           if release_label == "release-skip":
               # exit if skip release

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -104,9 +104,9 @@ jobs:
           import json
 
           def set_output(name, value):
-              with open(os.environ['GITHUB_ENV'], 'r') as fh:
+              with open(os.environ['GITHUB_OUTPUT'], 'r') as fh:
                   data = fh.read().strip()
-              with open(os.environ['GITHUB_ENV'], 'w') as fh:
+              with open(os.environ['GITHUB_OUTPUT'], 'w') as fh:
                   data += f"\n{name}={value}\n"    
                   fh.write(data)
           

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -23,9 +23,12 @@ on:
       calculated_version:
         description: "Calculated version"
         value: ${{ jobs.version_calc.outputs.calculated_version }}
-      calculated_bump_level:
-        description: "Calculated bump level"
-        value: ${{ jobs.version_calc.outputs.calculated_bump_level }}
+      release_override_found:
+        description: "Release override found"
+        value: ${{ jobs.version_calc.outputs.release_override_found }}
+      is_release:
+        description: "Is set to 'true' if its a release"
+        value: ${{ jobs.version_calc.outputs.is_release }}
     secrets:
       SOURCE_KEY:
         required: false
@@ -40,13 +43,18 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       calculated_version: ${{ steps.calculate_version.outputs.version }}
-      calculated_bump_level: ${{ steps.calculate_version.outputs.calculated_bump_level }}
+      release_override_found: ${{ steps.calculate_version.outputs.release_override_found }}
+      is_release: ${{ steps.calculate_version.outputs.is_release }}
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }} # we don't need the PR head sha, we need the base sha to calculate the next version
           fetch-depth: 0
+
+      - name: Add current title as commit for semantic release calculation
+        run: 
+          git commit --allow-empty -m "${{ github.event.pull_request.title }}"
 
       - name: Set up Python ${{ inputs.python_version }}
         uses: actions/setup-python@v3
@@ -62,7 +70,6 @@ jobs:
         shell: python
         id: calculate_version
         env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
           LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
           import subprocess
@@ -88,36 +95,48 @@ jobs:
           # Command to execute
           command = ["semantic-release", "--config", "${{ inputs.config_toml_file }}", "--noop", "version"]
           
-          # Check if we need to force a release
-          pr_title = os.getenv('PR_TITLE')
-          valid_pr_title = ['fix: ', 'fix!: ', 'feat: ', 'feat!: ', 'chore: ']
+
+          # verify labels and only run version calculation if its a release
+          # if skip we do not return any version/set is_release to true
+          # if more then one label we do not return any version//set is_release to true
           
-          title_pr_release_map = {
-            'fix: ': 'patch',
-            'fix!: ': 'major',
-            'feat: ': 'minor',
-            'feat!: ': 'major',
-            'chore: ': 'skip'
+          release_label_map = {
+              "release-skip": "",
+              "release-auto": "",
+              "release-patch": "--patch",
+              "release-minor": "--minor",
+              "release-major": "--major"
           }
-          forced_release = ''
-          if len(rel_labels) > 0:
-            if len(rel_labels) != 1:
-              print(f"WARNING! More than one release label found. Will use the first one. {rel_labels}", )
-            rel_label = rel_labels[0]
-            print("Release label found:", rel_labels[0])
-            if rel_label != "release-skip":
-              if rel_label == "release-auto":
-                # Use the pr_title_map to determine the release type
-                for key in title_pr_release_map.keys():
-                  if pr_title.startswith(key):
-                    forced_release = "--" + title_pr_release_map[key]
-                    command.append(forced_release)
-                    break
-              else:
-                forced_release = "--" + rel_label.split("-")[1]
-                command.append(forced_release)
+
+          release_label = "release-skip"
+
+          def check_label(label_name):
+              if label_name in release_label_map:
+                  release_label = label_name
+                  forced_release release_label_map[label_name]
+                  return 1
+              return 0
+
+
+          release_labels_found = 0
+          for label in rel_labels:
+              release_labels_found += check_label(label["name"])
+
+          if release_labels_found != 1:
+            # exit, if multible is set, then something is wrong and we really do not want to do any release
+            return
+
+          if release_label == "release-skip"
+            # exit if skip release
+            return
           
-          set_output('calculated_bump_level', forced_release)
+          if forced_release != ""
+            command.append(forced_release)
+
+
+          set_output('release_override_found', forced_release)
+          set_output('is_release', "true")
+
           print(command)          
           # Running the command and capturing output
           result = subprocess.run(command, capture_output=True, text=True)
@@ -134,3 +153,4 @@ jobs:
           
           # Set the output
           set_output('version', str(output))
+         

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -114,6 +114,7 @@ jobs:
           forced_release = ""
 
           def check_label(label_name):
+              global release_label, forced_release
               if label_name in release_label_map:
                   release_label = label_name
                   forced_release = release_label_map[label_name]

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -5,10 +5,10 @@ on:
   workflow_call:
     inputs:
       python_version:
-        description: 'Python version'
+        description: "Python version"
         type: string
         required: false
-        default: '3.11'
+        default: "3.11"
       config_toml_data:
         description: "Toml config file data for actions base64 encoded"
         type: string
@@ -57,6 +57,7 @@ jobs:
           git config --global user.email "dummy@dummy.com"
           git config --global user.name "dummy"
           git commit --allow-empty -m "${{ github.event.pull_request.title }}"
+          echo "LATEST_RELEASE_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
 
       - name: Set up Python ${{ inputs.python_version }}
         uses: actions/setup-python@v3
@@ -78,17 +79,17 @@ jobs:
           import os
           import json
           import base64
-          
+
           def deserialize_str(s):
             return base64.b64decode(s).decode('utf-8')
 
           def set_output(name, value):
             with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
                 print(f'{name}={value}', file=fh)
-          
+
           # Get up-to-date action_config.toml data from incoming PR branch.
           toml_data = json.loads(deserialize_str(b"${{ inputs.config_toml_data }}"))
-          
+
           label_names = json.loads(os.environ['LABELS'])
           rel_labels = [l for l in label_names if l.startswith('release-')]
           if len(rel_labels) == 0:
@@ -96,12 +97,12 @@ jobs:
 
           # Command to execute
           command = ["semantic-release", "--config", "${{ inputs.config_toml_file }}", "--noop", "version"]
-          
+
 
           # verify labels and only run version calculation if its a release
           # if skip we do not return any version/set is_release to true
           # if more then one label we do not return any version//set is_release to true
-          
+
           release_label_map = {
               "release-skip": "",
               "release-auto": "",
@@ -129,6 +130,7 @@ jobs:
           print(release_labels_found)
           print(release_label)
           print(forced_release)
+          print(env.LATEST_RELEASE_TAG)
 
           if release_labels_found != 1:
             # exit, if multible is set, then something is wrong and we really do not want to do any release
@@ -137,28 +139,28 @@ jobs:
           if release_label == "release-skip":
             # exit if skip release
             exit()
-          
+
           if forced_release != "":
             command.append(forced_release)
 
+          # debug print
+          print(command)      
 
-          set_output('release_override_found', forced_release)
-          set_output('is_release', "true")
-
-          print(command)          
           # Running the command and capturing output
           result = subprocess.run(command, capture_output=True, text=True)
 
           # Extracting the output
           output = result.stdout.strip()
-          
+
           # print any errors
           if result.stderr:
               print(result.stderr)
 
           # The version name should be in the output
           print(f'Captured Version Name: "{output}"')
-          
-          # Set the output
-          set_output('version', str(output))
-         
+
+          # Compare current tag with new so we know if its new
+          if "v" + str(output) != env.LATEST_RELEASE_TAG:
+            set_output('version', str(output))
+            set_output('release_override_found', forced_release)
+            set_output('is_release', "true")

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -124,7 +124,10 @@ jobs:
           for label in rel_labels:
               release_labels_found += check_label(label)
 
-
+          # temp debug..
+          print(release_labels_found)
+          print(release_label)
+          print(forced_release)
 
           if release_labels_found != 1:
             # exit, if multible is set, then something is wrong and we really do not want to do any release

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -124,13 +124,15 @@ jobs:
           for label in rel_labels:
               release_labels_found += check_label(label["name"])
 
+
+
           if release_labels_found != 1:
             # exit, if multible is set, then something is wrong and we really do not want to do any release
-            return
+            exit()
 
           if release_label == "release-skip":
             # exit if skip release
-            return
+            exit()
           
           if forced_release != "":
             command.append(forced_release)

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -167,6 +167,6 @@ jobs:
           if cur_version != new_version:
             print(cur_version)
             print(new_version)
-            set_output('version', new_version)
+            set_output('version', str(output))
             set_output('release_override_found', forced_release)
             set_output('is_release', "true")

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -42,7 +42,7 @@ jobs:
     name: Calculate semantic release version
     runs-on: ubuntu-latest
     outputs:
-      calculated_version: ${{ steps.calculate_version.outputs.version }}
+      calculated_version: ${{ steps.calculate_version.outputs.new_version }}
       release_override_found: ${{ steps.calculate_version.outputs.release_override_found }}
       is_release: ${{ steps.calculate_version.outputs.is_release }}
     steps:
@@ -164,9 +164,11 @@ jobs:
           cur_version = "${{ env.LATEST_RELEASE_TAG }}"
           new_version = f"v{output}"
 
+          # debug print
+          print(cur_version)
+          print(new_version)
+
           if cur_version != new_version:
-            print(cur_version)
-            print(new_version)
-            set_output('version', str(output))
+            set_output('new_version', str(output))
             set_output('release_override_found', forced_release)
             set_output('is_release', "true")

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -122,7 +122,7 @@ jobs:
 
           release_labels_found = 0
           for label in rel_labels:
-              release_labels_found += check_label(label["name"])
+              release_labels_found += check_label(label)
 
 
 

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -160,6 +160,10 @@ jobs:
           print(f'Captured Version Name: "{output}"')
 
           # Compare current tag with new so we know if its new
+          print("${{ env.LATEST_RELEASE_TAG }}")
+          print("v" + str(output)+"X")
+
+
           if "v" + str(output) != "${{ env.LATEST_RELEASE_TAG }}":
             set_output('version', str(output))
             set_output('release_override_found', forced_release)

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -57,7 +57,6 @@ jobs:
           git config --global user.email "dummy@dummy.com"
           git config --global user.name "dummy"
           git commit --allow-empty -m "${{ github.event.pull_request.title }}"
-          echo "LATEST_RELEASE_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
 
       - name: Set up Python ${{ inputs.python_version }}
         uses: actions/setup-python@v3
@@ -69,106 +68,117 @@ jobs:
           python -m pip install --upgrade pip
           pip install toml==0.10.2 python-semantic-release==8.1.1
 
+      - name: Get latest release tag
+        shell: python
+        run: |
+          import os
+          import re
+
+          def set_env(name, value):
+            with open(os.environ['GITHUB_ENV'], 'a') as fh:
+                print(f'{name}={value}', file=fh)
+
+          # get all tags and filter for semver format with prefix 'v'
+          all_tags = os.popen('git tag').read().splitlines()
+          semver_tags = [tag for tag in all_tags if re.match(r'^v\d+\.\d+\.\d+$', tag)]
+          if semver_tags:
+              # get the latest semver tag
+              semver_tags.sort(key=lambda s: list(map(int, s[1:].split('.'))), reverse=True)
+              latest_semver_tag = semver_tags[0]
+          else:
+              latest_semver_tag = 'v0.0.0'  # default if no semver tags found
+
+          set_env("LATEST_RELEASE_TAG", latest_semver_tag)
+
       - name: Check the calculated version from semantic release
         shell: python
         id: calculate_version
         env:
           LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          TOML_FILE: ${{ inputs.config_toml_file }}
         run: |
           import subprocess
           import os
           import json
-          import base64
-
-          def deserialize_str(s):
-            return base64.b64decode(s).decode('utf-8')
 
           def set_output(name, value):
-            with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-                print(f'{name}={value}', file=fh)
-
-          # Get up-to-date action_config.toml data from incoming PR branch.
-          toml_data = json.loads(deserialize_str(b"${{ inputs.config_toml_data }}"))
-
-          label_names = json.loads(os.environ['LABELS'])
-          rel_labels = [l for l in label_names if l.startswith('release-')]
+              with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+                  print(f"{name}={value}", file=fh)
+      
+          label_names = json.loads(os.environ["LABELS"])
+          rel_labels = [l for l in label_names if l.startswith("release-")]
           if len(rel_labels) == 0:
-            rel_labels.append('release-skip')
-
+              rel_labels.append("release-skip")
+      
           # Command to execute
-          command = ["semantic-release", "--config", "${{ inputs.config_toml_file }}", "--noop", "version"]
-
-
+          command = ["semantic-release", "--config", os.getenv("TOML_FILE"), "--noop", "version"]
+      
           # verify labels and only run version calculation if its a release
           # if skip we do not return any version/set is_release to true
           # if more then one label we do not return any version//set is_release to true
-
+      
           release_label_map = {
               "release-skip": "",
               "release-auto": "",
               "release-patch": "--patch",
               "release-minor": "--minor",
-              "release-major": "--major"
+              "release-major": "--major",
           }
-
-          def check_label(label_name, cur_count, cur_label, cur_force_release):
-              if label_name in release_label_map:
-                  return (cur_count + 1, label_name, release_label_map[label_name])
-              return (cur_count, cur_label, cur_force_release)
-
-          # defaults
-          release_labels_found = 0
-          release_label = "release-skip"
-          forced_release = ""
-
-          for label in rel_labels:
-              (release_labels_found, release_label, forced_release) = check_label(
-                  label, release_labels_found, release_label, forced_release)
-
+      
+          valid_labels = set(release_label_map.keys())
+          release_labels_found = len(valid_labels.intersection(set(rel_labels)))
+          if release_labels_found != 1:
+              if len(rel_labels) > 1:
+                  print("Multiple release labels found, please only use one release label")
+              else:
+                  print("No valid release label found, please use one of:")
+                  print(valid_labels)
+              # exit, if multiple is set, then something is wrong and we really do not want to do any release
+              exit(1)
+      
+          release_label = rel_labels[0]
+          forced_release = release_label_map[release_label]
+      
           # temp debug..
           print(rel_labels)
           print(release_labels_found)
           print(release_label)
           print(forced_release)
-          print("${{ env.LATEST_RELEASE_TAG }}")
-
-          if release_labels_found != 1:
-            # exit, if multible is set, then something is wrong and we really do not want to do any release
-            exit()
-
+          print(os.getenv("LATEST_RELEASE_TAG"))
+      
           if release_label == "release-skip":
-            # exit if skip release
-            exit()
-
+              # exit if skip release
+              exit(0)
+      
           if forced_release != "":
-            command.append(forced_release)
-
+              command.append(forced_release)
+      
           # debug print
-          print(command)      
-
+          print(command)
+      
           # Running the command and capturing output
           result = subprocess.run(command, capture_output=True, text=True)
-
+      
           # Extracting the output
           output = result.stdout.strip()
-
+      
           # print any errors
           if result.stderr:
               print(result.stderr)
-
+      
           # The version name should be in the output
           print(f'Captured Version Name: "{output}"')
-
+      
           # Compare current tag with new so we know if its new
-
-          cur_version = "${{ env.LATEST_RELEASE_TAG }}"
+      
+          cur_version = os.getenv("LATEST_RELEASE_TAG")
           new_version = f"v{output}"
-
+      
           # debug print
           print(cur_version)
           print(new_version)
-
+      
           if cur_version != new_version:
-            set_output('new_version', str(output))
-            set_output('release_override_found', forced_release)
-            set_output('is_release', "true")
+              set_output("new_version", str(output))
+              set_output("release_override_found", forced_release)
+              set_output("is_release", "true")

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -53,7 +53,9 @@ jobs:
           fetch-depth: 0
 
       - name: Add current title as commit for semantic release calculation
-        run: 
+        run: |
+          git config --global user.email "dummy@dummy.com"
+          git config --global user.name "dummy"
           git commit --allow-empty -m "${{ github.event.pull_request.title }}"
 
       - name: Set up Python ${{ inputs.python_version }}

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -180,6 +180,7 @@ jobs:
           print(f"{new_version=}")
       
           if cur_version != new_version:
+              print("New version found")
               set_output("new_version", str(output))
               set_output("release_override_found", forced_release)
               set_output("is_release", "true")

--- a/.github/workflows/tool-pr-version-calculate.yaml
+++ b/.github/workflows/tool-pr-version-calculate.yaml
@@ -110,21 +110,19 @@ jobs:
               "release-major": "--major"
           }
 
+          def check_label(label_name, cur_count, cur_label, cur_force_release):
+              if label_name in release_label_map:
+                  return (cur_count + 1, label_name, release_label_map[label_name])
+              return (cur_count, cur_label, cur_force_release)
+
+          # defaults
+          release_labels_found = 0
           release_label = "release-skip"
           forced_release = ""
 
-          def check_label(label_name):
-              global release_label, forced_release
-              if label_name in release_label_map:
-                  release_label = label_name
-                  forced_release = release_label_map[label_name]
-                  return 1
-              return 0
-
-
-          release_labels_found = 0
           for label in rel_labels:
-              release_labels_found += check_label(label)
+              (release_labels_found, release_label, forced_release) = check_label(
+                  label, release_labels_found, release_label, forced_release)
 
           # temp debug..
           print(rel_labels)

--- a/.github/workflows/tool-release-docker.yaml
+++ b/.github/workflows/tool-release-docker.yaml
@@ -52,6 +52,7 @@ env:
 jobs:
   build_docker:
     name: Build Docker "${{ matrix.docker.ref_name }}"
+    if: matrix.docker.enabled == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/tool-release-docker.yaml
+++ b/.github/workflows/tool-release-docker.yaml
@@ -52,7 +52,7 @@ env:
 jobs:
   build_docker:
     name: Build Docker "${{ matrix.docker.ref_name }}"
-    if: matrix.docker.enabled == 'true'
+    if: ${{ matrix.docker.enabled == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/tool-release-docker.yaml
+++ b/.github/workflows/tool-release-docker.yaml
@@ -52,27 +52,38 @@ env:
 jobs:
   build_docker:
     name: Build Docker "${{ matrix.docker.ref_name }}"
-    if: ${{ matrix.docker.enabled == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(inputs.docker_matrix) }}
+      matrix: ${{ fromJson( inputs.docker_matrix ) }}
     steps:
+      - name: Check if matrix.docker.enabled is true
+        id: check_docker_enabled
+        run: |
+          if [[ "${{ matrix.docker.enabled }}" == "false" ]]; then
+            echo "Docker is disabled for this tool"
+            echo "DOCKER_DISABLED=true" >> $GITHUB_ENV
+          fi
+
       - name: Checkout git
+        if: env.DOCKER_DISABLED != 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - uses: actions/setup-python@v4
+        if: env.DOCKER_DISABLED != 'true'
         with:
           python-version: ${{ inputs.python_version }}
 
       - name: Install deps
+        if: env.DOCKER_DISABLED != 'true'
         run: |
           pip install --upgrade pip
           pip install toml==0.10.2
 
       - name: Check if release override contains "next"
+        if: env.DOCKER_DISABLED != 'true'
         id: check_release_override
         env:
           INPUT_DOCKER_TAG_OVERRIDE: ${{ inputs.docker_tag_override }}
@@ -95,7 +106,7 @@ jobs:
               set_env('IS_PRE_RELEASE', 'false')
 
       - name: Update pyproject.toml and package.json (if exists) on pre-release
-        if: env.IS_PRE_RELEASE == 'true'
+        if: env.IS_PRE_RELEASE == 'true' && env.DOCKER_DISABLED != 'true'
         env:
           INPUT_DOCKER_TAG_OVERRIDE: ${{ inputs.docker_tag_override }}
         shell: python
@@ -154,12 +165,12 @@ jobs:
                     json.dump(json_data, file)
 
       - name: Build docker image with ${{ steps.set_release_tag.outputs.docker_tag }} tag
-        if: inputs.create_build_logs == 'false'
+        if: inputs.create_build_logs == 'false' && env.DOCKER_DISABLED != 'true'
         run: |
           docker build -f ${{ matrix.docker.context }}/${{ matrix.docker.docker_file }} -t ${{ secrets.CONTAINER_REGISTRY_URL }}/${{ matrix.docker.team_name }}/${{ matrix.docker.image_name }}:${{ inputs.docker_tag_override }} ${{ matrix.docker.context }}
 
       - name: Build docker image with latest tag
-        if: (inputs.docker_use_latest == 'true') || (inputs.create_build_logs == 'true')
+        if: ((inputs.docker_use_latest == 'true') || (inputs.create_build_logs == 'true')) && env.DOCKER_DISABLED != 'true'
         run: |
           docker build -f ${{ matrix.docker.context }}/${{ matrix.docker.docker_file }} -t ${{ secrets.CONTAINER_REGISTRY_URL }}/${{ matrix.docker.team_name }}/${{ matrix.docker.image_name }}:latest ${{ matrix.docker.context }}
           # if inputs.create_build_logs == 'true' then we will echo to file
@@ -169,7 +180,7 @@ jobs:
           fi
 
       - name: Upload Build Log
-        if: inputs.create_build_logs == 'true'
+        if: inputs.create_build_logs == 'true' && env.DOCKER_DISABLED != 'true'
         uses: actions/upload-artifact@v3
         continue-on-error: true # Needed to continue in the event the build fails and no build log is found
         with:
@@ -177,7 +188,7 @@ jobs:
           path: build_log_docker_${{ github.run_id }}_${{ matrix.docker.ref_name }}.txt
 
       - name: Source - login to ACR
-        if: inputs.push_docker == 'true'
+        if: inputs.push_docker == 'true' && env.DOCKER_DISABLED != 'true'
         uses: docker/login-action@v3.0.0
         with:
           registry: ${{ secrets.CONTAINER_REGISTRY_URL }}
@@ -185,12 +196,12 @@ jobs:
           password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
 
       - name: Push docker image with ${{ inputs.docker_tag_override }} tag
-        if: inputs.push_docker == 'true'
+        if: inputs.push_docker == 'true' && env.DOCKER_DISABLED != 'true'
         run: |
           docker push ${{ secrets.CONTAINER_REGISTRY_URL }}/${{ matrix.docker.team_name }}/${{ matrix.docker.image_name }}:${{ inputs.docker_tag_override }}
 
       - name: Push docker image with latest tag
-        if: inputs.docker_use_latest == 'true' && inputs.docker_push == 'true' && env.IS_PRE_RELEASE == 'false'
+        if: inputs.docker_use_latest == 'true' && inputs.docker_push == 'true' && env.IS_PRE_RELEASE == 'false' && env.DOCKER_DISABLED != 'true'
         run: |
           docker push ${{ secrets.CONTAINER_REGISTRY_URL }}/${{ matrix.docker.team_name }}/${{ matrix.docker.image_name }}:latest
 

--- a/.github/workflows/tool-release-docker.yaml
+++ b/.github/workflows/tool-release-docker.yaml
@@ -58,7 +58,6 @@ jobs:
       matrix: ${{ fromJson( inputs.docker_matrix ) }}
     steps:
       - name: Check if matrix.docker.enabled is true
-        id: check_docker_enabled
         run: |
           if [[ "${{ matrix.docker.enabled }}" == "false" ]]; then
             echo "Docker is disabled for this tool"

--- a/.github/workflows/tool-release-gitops-update.yaml
+++ b/.github/workflows/tool-release-gitops-update.yaml
@@ -64,22 +64,29 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix: ${{ fromJson(inputs.gitops_matrix) }}
-#    permissions:
-#      id-token: write
-#      contents: write
 
     steps:
+      - name: Check if matrix.docker.enabled is true
+        run: |
+          if [[ "${{ matrix.gitops.enabled }}" == "false" ]]; then
+            echo "Gitops is disabled for this tool"
+            echo "GITOPS_DISABLED=true" >> $GITHUB_ENV
+          fi
+
       - name: Set up Python ${{ inputs.python_version }}
+        if: env.GITOPS_DISABLED != 'true'
         uses: actions/setup-python@v3
         with:
           python-version: ${{ inputs.python_version }}
 
       - name: Install python dependencies
+        if: env.GITOPS_DISABLED != 'true'
         run: |
           python -m pip install --upgrade pip
           pip install ruamel.yaml==${{inputs.python_yaml_pkg}}
 
       - name: Checkout gitops
+        if: env.GITOPS_DISABLED != 'true'
         uses: actions/checkout@v4
         with:
           ref: main
@@ -89,6 +96,7 @@ jobs:
           path: gitops
 
       - name: Collect gitops config
+        if: env.GITOPS_DISABLED != 'true'
         env:
           DOCKER_MATRIX: ${{ inputs.docker_matrix }}
         working-directory: ./gitops
@@ -127,6 +135,7 @@ jobs:
               yaml.dump_all(yaml_blocks, f)
 
       - name: Gitops - commit yaml
+        if: env.GITOPS_DISABLED != 'true'
         working-directory: ./gitops
         run: |
           git config user.name github-actions
@@ -135,13 +144,13 @@ jobs:
           git commit --allow-empty -m "Test updated ${{ matrix.gitops.docker_ref }}:${{ inputs.release_tag_override }}"
 
       - name: Gitops - push yaml
-        if: inputs.push_commit == 'true'
+        if: inputs.push_commit == 'true' && env.GITOPS_DISABLED != 'true'
         working-directory: ./gitops
         run: |
           git push
 
       - name: Gitops - log
-        if: inputs.create_run_logs == 'true'
+        if: inputs.create_run_logs == 'true' && env.GITOPS_DISABLED != 'true'
         id: update_log
         run: |
           echo "congratuations, you updated ${{ matrix.gitops.docker_ref }}:${{ inputs.release_tag_override }}"
@@ -149,7 +158,7 @@ jobs:
           echo "${{ matrix.gitops.docker_ref }}" >> build_log_gitops_${{ github.run_id }}_${{ matrix.gitops.docker_ref }}.txt
 
       - name: Upload Build Log
-        if: inputs.create_run_logs == 'true'
+        if: inputs.create_run_logs == 'true' && env.GITOPS_DISABLED != 'true'
         uses: actions/upload-artifact@v3
         continue-on-error: true # Needed to continue in the event the build fails and no build log is found
         with:
@@ -201,7 +210,7 @@ jobs:
           
           docker_enabled_ref_names = {x["ref_name"] for x in docker_matrix["docker"] if x["enabled"]}
           
-          docker_images = {x["docker_ref"] for x in gitops_matrix["gitops"]}
+          docker_images = {x["docker_ref"] for x in gitops_matrix["gitops"] if x["enabled"]
           
           print("Docker Images:", docker_images)
           
@@ -219,11 +228,12 @@ jobs:
           
           # Check if docker
           if docker_enabled_ref_names != docker_images:
-            run_review_str += "\n* ❌ Docker images were not built for all enabled docker refs"
-            
+            run_review_str += "\n* ❌ Number of enabled docker images does not match enabled gitops docker_refs."
+
             # find the gitops refs that were not built
             missing_docker_images = docker_images - docker_enabled_ref_names
-            run_review_str += "\n  * Docker image ref issues: " + ", ".join(missing_docker_images)
+            for missing_docker_image in missing_docker_images:
+              run_review_str += f"\n  * {missing_docker_image} was not built"
           
           else:
             run_review_str += "\n* ✅ Docker images were built for all enabled docker refs"

--- a/.github/workflows/tool-release-gitops-update.yaml
+++ b/.github/workflows/tool-release-gitops-update.yaml
@@ -175,6 +175,7 @@ jobs:
         id: summarize_build_logs  # Set an ID for this step to reference its outputs
         env:
           GITOPS_MATRIX: ${{ inputs.gitops_matrix }}
+          DOCKER_MATRIX: ${{ inputs.docker_matrix }}
         shell: python
         run: |
           import os
@@ -196,13 +197,16 @@ jobs:
           
           # check if the gitops update was successful or not
           gitops_matrix = json.loads(os.environ['GITOPS_MATRIX'])
+          docker_matrix = json.loads(os.environ['DOCKER_MATRIX'])
           
-          docker_images = [x["docker_ref"] for x in gitops_matrix["gitops"]]
+          docker_enabled_ref_names = {x["ref_name"] for x in docker_matrix["docker"] if x["enabled"]}
+          
+          docker_images = {x["docker_ref"] for x in gitops_matrix["gitops"]}
           
           print("Docker Images:", docker_images)
           
           # Compare build_logs and docker_images and ensure that they are equal disregarding order
-          has_docker_build = set(docker_images) == set(build_logs)
+          has_docker_build = docker_images == set(build_logs)
           if has_docker_build:
             set_output('build_log_ok', "true")
           else:
@@ -213,4 +217,16 @@ jobs:
           else:
             run_review_str = "\n* ❌ Gitops update dry-run was not successful"
           
+          # Check if docker
+          if docker_enabled_ref_names != docker_images:
+            run_review_str += "\n* ❌ Docker images were not built for all enabled docker refs"
+            
+            # find the gitops refs that were not built
+            missing_docker_images = docker_images - docker_enabled_ref_names
+            run_review_str += "\n  * Docker image ref issues: " + ", ".join(missing_docker_images)
+          
+          else:
+            run_review_str += "\n* ✅ Docker images were built for all enabled docker refs"
+          
+          print(f"{run_review_str=}")
           set_output('build_log_summary', run_review_str, True)

--- a/.github/workflows/tool-release-gitops-update.yaml
+++ b/.github/workflows/tool-release-gitops-update.yaml
@@ -119,7 +119,7 @@ jobs:
           image_name = docker_to_gitops["image_name"]
           tag = "${{ inputs.release_tag_override }}"
           
-          docker_image = "${{ secrets.CONTAINER_REGISTRY_URL }}" + f"/{team_name}/{image_name}:{tag}"
+          docker_image = "${{ secrets.CONTAINER_REGISTRY_URL }}" + f"/{team_name}/{image_name}:{tag}" + " # github branch name/ref name: ${{ github.ref_name }}/ ${{ github.ref }}"
           gitops_file = "${{ matrix.gitops.file }}"
           kind = "${{ matrix.gitops.kind }}"
         

--- a/.github/workflows/tool-release-gitops-update.yaml
+++ b/.github/workflows/tool-release-gitops-update.yaml
@@ -235,7 +235,7 @@ jobs:
             # find the gitops refs that were not built
             missing_docker_images = docker_images - docker_enabled_ref_names
             for missing_docker_image in missing_docker_images:
-              run_review_str += f"\n  * {missing_docker_image} was not built"
+              run_review_str += f'\n  * "{missing_docker_image}" was not built'
           
           else:
             run_review_str += "\n* ✅ Docker images were built for all enabled docker refs"

--- a/.github/workflows/tool-release-gitops-update.yaml
+++ b/.github/workflows/tool-release-gitops-update.yaml
@@ -100,6 +100,7 @@ jobs:
         env:
           DOCKER_MATRIX: ${{ inputs.docker_matrix }}
         working-directory: ./gitops
+        continue-on-error: true
         shell: python
         run: |
           import ruamel.yaml

--- a/.github/workflows/tool-release-gitops-update.yaml
+++ b/.github/workflows/tool-release-gitops-update.yaml
@@ -119,7 +119,7 @@ jobs:
           image_name = docker_to_gitops["image_name"]
           tag = "${{ inputs.release_tag_override }}"
           
-          docker_image = "${{ secrets.CONTAINER_REGISTRY_URL }}" + f"/{team_name}/{image_name}:{tag}" + " # github branch name/ref name: ${{ github.ref_name }}/ ${{ github.ref }}"
+          docker_image = "${{ secrets.CONTAINER_REGISTRY_URL }}" + f"/{team_name}/{image_name}:{tag}"
           gitops_file = "${{ matrix.gitops.file }}"
           kind = "${{ matrix.gitops.kind }}"
         

--- a/.github/workflows/tool-release-gitops-update.yaml
+++ b/.github/workflows/tool-release-gitops-update.yaml
@@ -210,7 +210,7 @@ jobs:
           
           docker_enabled_ref_names = {x["ref_name"] for x in docker_matrix["docker"] if x["enabled"]}
           
-          docker_images = {x["docker_ref"] for x in gitops_matrix["gitops"] if x["enabled"]
+          docker_images = {x["docker_ref"] for x in gitops_matrix["gitops"] if x["enabled"]}
           
           print("Docker Images:", docker_images)
           

--- a/.github/workflows/tool-release-gitops-update.yaml
+++ b/.github/workflows/tool-release-gitops-update.yaml
@@ -217,18 +217,19 @@ jobs:
           
           # Compare build_logs and docker_images and ensure that they are equal disregarding order
           has_docker_build = docker_images == set(build_logs)
-          if has_docker_build:
-            set_output('build_log_ok', "true")
-          else:
-            set_output('build_log_ok', "false")
           
+          all_checks = []
+          all_checks.append(has_docker_build)
           if has_docker_build:
             run_review_str = "\n* ✅ Gitops update dry-run was successful"
           else:
             run_review_str = "\n* ❌ Gitops update dry-run was not successful"
           
-          # Check if docker
-          if docker_enabled_ref_names != docker_images:
+          # Check if docker images were built for all enabled docker refs
+          docker_gitops_match = docker_enabled_ref_names == docker_images
+          all_checks.append(docker_gitops_match)
+          
+          if not docker_gitops_match:
             run_review_str += "\n* ❌ Number of enabled docker images does not match enabled gitops docker_refs."
 
             # find the gitops refs that were not built
@@ -238,6 +239,11 @@ jobs:
           
           else:
             run_review_str += "\n* ✅ Docker images were built for all enabled docker refs"
+          
+          if all(all_checks):
+            set_output('build_log_ok', "true")
+          else:
+            set_output('build_log_ok', "false")
           
           print(f"{run_review_str=}")
           set_output('build_log_summary', run_review_str, True)

--- a/.github/workflows/tool-review-docker.yaml
+++ b/.github/workflows/tool-review-docker.yaml
@@ -127,7 +127,7 @@ jobs:
           
           print("Build Log:", build_logs)
           docker_matrix = json.loads(os.environ['DOCKER_MATRIX_STR'])["docker"]
-          docker_images = [x["ref_name"] for x in docker_matrix]
+          docker_images = [x["ref_name"] for x in docker_matrix if x["enabled"]]
           
           print("Docker Images:", docker_images)
           

--- a/.github/workflows/tool-review-gitops.yaml
+++ b/.github/workflows/tool-review-gitops.yaml
@@ -97,7 +97,7 @@ jobs:
             return base64.b64decode(s).decode('utf-8')
           
           # GITOPS Review results
-          body = "# Gitops Review:\n\n"
+          body = "\n# Gitops Review:\n\n"
           
           # Check if gitops updates dry run was successful or not
           update_logs_ok = '${{ needs.test_gitops.outputs.update_logs_ok }}' == 'true' 

--- a/.github/workflows/tool-review-pr.yaml
+++ b/.github/workflows/tool-review-pr.yaml
@@ -112,7 +112,7 @@ jobs:
             body += "\n * ✅ SOURCE_KEY is set as a secret"
           
           next_version = "${{ needs.pr-version-calculate.outputs.calculated_version }}"
-          
+          print(f"{next_version=}")
           if next_version == "":
             body += f'\n * ✅ Skipping release'
           else:

--- a/.github/workflows/tool-review-pr.yaml
+++ b/.github/workflows/tool-review-pr.yaml
@@ -112,6 +112,10 @@ jobs:
             body += "\n * ✅ SOURCE_KEY is set as a secret"
           
           next_version = "${{ needs.pr-version-calculate.outputs.calculated_version }}"
+          
+          if next_version == "":
+             next_version = "N/A (skipping release)"
+          
           body += f'\n * ✅ Calculated next version: "{next_version}"'
           
           # Set the output

--- a/.github/workflows/tool-review-pr.yaml
+++ b/.github/workflows/tool-review-pr.yaml
@@ -74,6 +74,7 @@ jobs:
                 print(f'{name}={value}', file=fh)
           
           # PR lint results
+          pr_calc_issue_str = '${{ needs.pr-version-calculate.outputs.issue_str }}'
           has_source_key = '${{ needs.pr-lint-checker.outputs.has_source_key_secret }}' == 'true'
           check_pr_title = '${{ needs.pr-lint-checker.outputs.check_pr_title }}' == 'true'
           check_release_label = '${{ needs.pr-lint-checker.outputs.check_release_label }}' == 'true'
@@ -82,12 +83,18 @@ jobs:
           
           body = "\n# PR Review:\n\n"
           
+          if pr_calc_issue_str != "":
+            all_checks.append(False)
+          
           if all(all_checks):
             body += "I found no pr-related issues.\n"
             set_output('PR_REVIEW_OK', 'true')
           else:
             body += "I found some pr-related issues:\n\n"
             set_output('PR_REVIEW_OK', 'false')
+          
+          if pr_calc_issue_str != "":
+            body += f"\n * ❌ {pr_calc_issue_str}"
           
           if check_pr_title is False:
             body += "\n * ❌ You need to start PR title with fix: feat: fix!: feat!: chore:"

--- a/.github/workflows/tool-review-pr.yaml
+++ b/.github/workflows/tool-review-pr.yaml
@@ -114,9 +114,9 @@ jobs:
           next_version = "${{ needs.pr-version-calculate.outputs.calculated_version }}"
           
           if next_version == "":
-             next_version = "N/A (skipping release)"
-          
-          body += f'\n * ✅ Calculated next version: "{next_version}"'
+            body += f'\n * ✅ Skipping release'
+          else:
+            body += f'\n * ✅ Calculated next version: "{next_version}"'
           
           # Set the output
           set_output('body', body, True)


### PR DESCRIPTION

* skip release was not used
* calculation moved to be just done by sematic release/should be more correct now
* renamed summary workflow/misc input descriptions

⚠️ I will need to test more before considering merging!!